### PR TITLE
fix: Add Flask-WTF to dependencies

### DIFF
--- a/flask_nocobase_importer/requirements.txt
+++ b/flask_nocobase_importer/requirements.txt
@@ -9,3 +9,4 @@ Flask-Talisman
 Flask-RQ2
 redis
 minio
+Flask-WTF


### PR DESCRIPTION
Resolves ModuleNotFoundError for flask_wtf by adding Flask-WTF to the requirements.txt file. This is essential for the form functionality used in NocoBase profile management.