### PR TITLE
fix: Ensure FLASK_APP is configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,14 @@ FLASK_SESSION_COOKIE_SECURE=True # Set to True if app is served over HTTPS
 # INFO: Maximum file upload size is configured in app.py (currently 16MB)
 # FLASK_DEBUG=True # Uncomment for development debugging
 
-# Flask Run Configuration (used by 'flask run' command, set in Dockerfile or by Docker)
-# These are often set in the Dockerfile or Docker run command, but shown here for completeness
-# FLASK_APP=flask_nocobase_importer.app
-# FLASK_RUN_HOST=0.0.0.0
-FLASK_RUN_PORT=5000
+# Flask Application Discovery & CLI Configuration
+# FLASK_APP is crucial for 'flask' CLI commands (like 'flask run', 'flask rq') to find your application.
+# It's used by the worker service in docker-compose.yml and when running workers manually.
+# The Dockerfile also sets a default, but this ensures it's explicit if using an .env file with Docker Compose.
+FLASK_APP=flask_nocobase_importer.app
+# FLASK_RUN_HOST is used if running 'flask run' directly. Gunicorn in Dockerfile uses its own bind.
+# FLASK_RUN_HOST=0.0.0.0 
+FLASK_RUN_PORT=5000 # Port for 'flask run', Gunicorn uses its own port config.
 
 # Redis Configuration (for RQ task queue)
 REDIS_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -169,9 +169,16 @@ While Docker Compose (`docker-compose up`) is the recommended way to run all ser
     This command tells the worker to connect to your Redis instance (using the `REDIS_URL` from your environment or defaulting to `redis://localhost:6379/0`) and process jobs on the `default` queue. You can list multiple queues if needed.
 
 **Troubleshooting Worker Startup:**
-*   **`Error: Could not locate a Flask application.`**: This usually means `FLASK_APP` is not set correctly or you are not in the project root directory. Verify the variable and your current path.
-*   **`Error: No such command 'rq'.`**: This typically means the virtual environment isn't activated, `Flask-RQ2` is not installed properly, or there's an issue with your Python environment's PATH. Ensure `pip install -r requirements.txt` was successful.
-*   **Connection Errors to Redis/MinIO/DB**: Ensure these services are running and accessible, and that your `.env` file has the correct connection details.
+*   **`Error: Could not locate a Flask application.`** or **`Error: No such command 'rq'.`**: 
+    These errors usually indicate that the Flask CLI cannot find your application, which prevents custom commands like `rq` from being registered.
+    *   **When using Docker Compose**: Ensure the `FLASK_APP` variable is correctly set in your `.env` file (e.g., `FLASK_APP=flask_nocobase_importer.app`). Docker Compose loads this `.env` file to configure the services, including the worker. The `Dockerfile` sets a default, but an incorrect or empty `FLASK_APP` in the `.env` file can cause issues.
+    *   **When running manually (outside Docker Compose)**: Make sure you have set the `FLASK_APP` environment variable in your current shell session (e.g., `export FLASK_APP=flask_nocobase_importer.app`) AND that you are running the `flask rq worker` command from the project's root directory (the one containing the `flask_nocobase_importer` folder).
+    *   Verify the `FLASK_APP` value matches the path to your Flask application instance (usually `filename.py:instance_name`).
+
+*   **`Error: No such command 'rq'.` (if Flask app seems to load but 'rq' is still missing)**: 
+    If `FLASK_APP` seems correct but `rq` is still not found, this could also mean that `Flask-RQ2` is not installed properly in the environment the worker is using, or the virtual environment (if used locally) isn't activated. Ensure dependencies from `requirements.txt` are installed.
+
+*   **Connection Errors to Redis**: Ensure your Redis server (e.g., the `redis` service in Docker Compose, or your local Redis server) is running and accessible at the URL specified in your `REDIS_URL` environment variable.
 
 Using `python -m flask ...` can sometimes be more reliable than just `flask ...` if you have multiple Python versions or complex environments.
 


### PR DESCRIPTION
Updates `.env.example` to uncomment and correctly define FLASK_APP, as this is crucial for the Flask CLI to locate the application, especially for RQ processes started via `flask rq worker`.

Also enhances `README.md` with more detailed troubleshooting steps for "Could not locate a Flask application" and "No such command 'rq'" errors, guiding you to check your FLASK_APP configuration in your `.env` file or shell environment.