### PR TITLE
fix: Correct RQ command by removing -u option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ While Docker Compose (`docker-compose up`) is the recommended way to run all ser
 
 5.  **Start the Worker**: From your project root directory, run the following command:
     ```bash
-    python -m flask rq worker -u ${REDIS_URL:-redis://localhost:6379/0} default
+    python -m flask rq worker default
     ```
     Or, if `FLASK_APP` is correctly set and your environment resolves the `flask` command directly:
     ```bash
-    flask rq worker -u ${REDIS_URL:-redis://localhost:6379/0} default
+    flask rq worker default
     ```
-    This command tells the worker to connect to your Redis instance (using the `REDIS_URL` from your environment or defaulting to `redis://localhost:6379/0`) and process jobs on the `default` queue. You can list multiple queues if needed.
+    This command tells the worker to process jobs on the `default` queue (you can list multiple queues if needed). The worker will connect to your Redis instance using the `REDIS_URL` environment variable defined in your shell or `.env` file (which is loaded by Flask). Ensure `REDIS_URL` is set correctly (e.g., `export REDIS_URL=redis://localhost:6379/0`).
 
 **Troubleshooting Worker Startup:**
 *   **`Error: Could not locate a Flask application.`** or **`Error: No such command 'rq'.`**: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,9 @@ services:
   worker:
     build: . # Uses the same Dockerfile as web
     container_name: nocobase_importer_worker
-    command: python -m flask rq worker -u redis://redis:6379/0 default
+    command: python -m flask rq worker default
     # Alternative command if flask CLI not directly usable or app context issues:
-    # command: python -m flask rq worker -u redis://redis:6379/0 default
+    # command: python -m flask rq worker default
     volumes:
       # Mounts the flask_nocobase_importer app code for development (optional for production)
       # - ./flask_nocobase_importer:/app/flask_nocobase_importer


### PR DESCRIPTION
Removes the `-u <URL>` option from the `flask rq` command in `docker-compose.yml` and updates `README.md` documentation for manual startup accordingly.

Flask-RQ2 uses the `REDIS_URL` environment variable (set in Flask app config) to connect to Redis, making the `-u` command-line option unnecessary and potentially causing "No such option: -u" errors with current versions.